### PR TITLE
Log exception cause

### DIFF
--- a/src/pyfaktory/consumer.py
+++ b/src/pyfaktory/consumer.py
@@ -150,7 +150,7 @@ class Consumer:
 
             if err.__cause__ and type(err.__cause__) == RemoteTraceback:
                 # Pebble will provide us the real exception in err.__cause__
-                backtrace = str(err.__cause__)
+                backtrace = str(err.__cause__).split('\n')
             else:
                 # Otherwise just fallback to the exception we have here.
                 backtrace = traceback.format_tb(err_traceback)
@@ -158,8 +158,7 @@ class Consumer:
             self.client._fail(jid=future.job_id,
                               errtype=err_type.__name__,
                               message=str(err_value),
-                              backtrace=backtrace,
-                              limit=future.backtrace)
+                              backtrace=backtrace)
         finally:
             with self.lock_pending_tasks_count:
                 self.pending_tasks_count -= 1

--- a/src/pyfaktory/consumer.py
+++ b/src/pyfaktory/consumer.py
@@ -193,7 +193,7 @@ class Consumer:
 
                 if self.pending_tasks_count < self.concurrency:
                     queues_tmp = self.get_queues()
-                    self.logger.info(f'Fetching from queues: {queues_tmp}')
+                    self.logger.debug(f'Fetching from queues: {queues_tmp}')
                     # If no jobs are found, _fatch will block for up
                     # to 2 seconds on the first queue provided.
                     job = self.client._fetch(queues_tmp)


### PR DESCRIPTION
two things I want to fix 

* The log levels for a few things were wrong,  the `Fetching from queus` should be debug!  And if a job fails, we need to get a log at level ERROR. 
* I also have noticed that stack traces in faktory are not actually correct.  they are the exception when resolving the future, not the actual traceback that threw the exception.  Turns out this is handled automatically when you use `logger.exception` so that's great.  But then also to pass the right string back to faktory you need to use `err.__cause__` to get the actual exception that Pebble copied over from the child process. 